### PR TITLE
Fix fastfile build errors

### DIFF
--- a/apps/gpc-prover-client/next.config.js
+++ b/apps/gpc-prover-client/next.config.js
@@ -4,6 +4,10 @@ module.exports = {
   transpilePackages: ["@repo/ui"],
   webpack: (config, { isServer }) => {
     if (!isServer) {
+      // required for fastfile
+      // fastfile uses node modules "fs", "constants",
+      // and global "process" (process.browser)
+      // see details here: https://github.com/proofcarryingdata/zukyc/pull/3
       config.resolve.fallback = {
         fs: false
       };

--- a/apps/gpc-prover-client/next.config.js
+++ b/apps/gpc-prover-client/next.config.js
@@ -1,10 +1,17 @@
 /** @type {import('next').NextConfig} */
+
 module.exports = {
   transpilePackages: ["@repo/ui"],
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve.fallback = {
         fs: false
+      };
+      config.resolve.alias = {
+        constants: require.resolve(
+          "rollup-plugin-node-polyfills/polyfills/constants"
+        ),
+        process: "process/browser"
       };
     }
 

--- a/apps/gpc-prover-client/package.json
+++ b/apps/gpc-prover-client/package.json
@@ -12,10 +12,10 @@
     "@pcd/gpc": "^0.0.3",
     "@pcd/pod": "^0.1.2",
     "@semaphore-protocol/identity": "^3.15.2",
-    "fastfile": "git+https://github.com/iden3/fastfile.git",
     "next": "^14.1.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "rollup-plugin-node-polyfills": "^0.2.1"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^14.1.1",
@@ -28,8 +28,5 @@
     "eslint": "^8.57.0",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.3.3"
-  },
-  "resolutions": {
-    "@pcd/gpcircuits/**/fastfile": "git+https://github.com/iden3/fastfile.git"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -726,9 +726,9 @@
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
 "@types/lodash@^4.17.1":
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.5.tgz#e6c29b58e66995d57cd170ce3e2a61926d55ee04"
-  integrity sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==
+  version "4.17.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.6.tgz#193ced6a40c8006cfc1ca3f4553444fb38f0e543"
+  integrity sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==
 
 "@types/mime@^1":
   version "1.3.5"
@@ -2528,6 +2528,11 @@ estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -2627,12 +2632,8 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
 
 fastfile@0.0.20:
   version "0.0.20"
-  resolved "https://github.com/iden3/fastfile.git#5dd61839976b576f85d3784a6d55c64c3c64408d"
-
-"fastfile@ssh://git@github.com:iden3/fastfile.git":
-  version "0.0.20"
-  uid "5dd61839976b576f85d3784a6d55c64c3c64408d"
-  resolved "ssh://git@github.com:iden3/fastfile.git#5dd61839976b576f85d3784a6d55c64c3c64408d"
+  resolved "https://registry.yarnpkg.com/fastfile/-/fastfile-0.0.20.tgz#794a143d58cfda2e24c298e5ef619c748c8a1879"
+  integrity sha512-r5ZDbgImvVWCP0lA/cGNgQcZqR+aYdFx3u+CtJqUE510pBUVGMn4ulL/iRTI4tACTYsNJ736uzFxEBXesPAktA==
 
 fastq@^1.6.0:
   version "1.17.1"
@@ -3764,6 +3765,13 @@ lru-cache@^7.14.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
+magic-string@^0.25.3:
+  version "0.25.9"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
+  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
+  dependencies:
+    sourcemap-codec "^1.4.8"
+
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
@@ -4721,6 +4729,29 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rollup-plugin-inject@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz#e4233855bfba6c0c12a312fd6649dff9a13ee9f4"
+  integrity sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==
+  dependencies:
+    estree-walker "^0.6.1"
+    magic-string "^0.25.3"
+    rollup-pluginutils "^2.8.1"
+
+rollup-plugin-node-polyfills@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz#53092a2744837164d5b8a28812ba5f3ff61109fd"
+  integrity sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==
+  dependencies:
+    rollup-plugin-inject "^3.0.0"
+
+rollup-pluginutils@^2.8.1:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
+  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
+  dependencies:
+    estree-walker "^0.6.1"
+
 run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -4989,6 +5020,11 @@ source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sourcemap-codec@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
"@pcd/gpc" has dependency "@pcd/gpcircuits" which in turn depends on [fastfile](https://github.com/iden3/fastfile/tree/master).

"fastfile" uses node modules "fs", "constants" and global "process" (process.browser).
We need to polyfill these in order for it to work in browser.

Otherwise, here is the build error I'm getting when running "yarn build"
```
../../node_modules/fastfile/src/fastfile.js
Can't import the named export 'O_CREAT' (imported as 'O_CREAT') from default-exporting module (only default export is available)

Import trace for requested module:
../../node_modules/fastfile/src/fastfile.js
../../node_modules/@pcd/gpcircuits/dist/esm/src/artifacts.js
../../node_modules/@pcd/gpcircuits/dist/esm/src/index.js
../../node_modules/@pcd/gpc/dist/esm/src/gpc.js
../../node_modules/@pcd/gpc/dist/esm/src/index.js
./app/util/generateProof.ts
./app/prover/page.tsx
```
This PR (see next.config.js) shows how to fix it in Next.js (uses webpack 5). 

----

snark.js uses rollup, and [here is how it does the polyfill](https://github.com/iden3/snarkjs/blob/master/config/rollup.browser.esm.config.js).

----

zupass repo uses esbuild, and [it uses the the plugin from "@esbuild-plugins/node-modules-polyfill" to do the polyfill](https://github.com/proofcarryingdata/zupass/blob/main/apps/consumer-client/build.ts#L23).


