### PR TITLE
Use @semaphore-protocol/identity instead

### DIFF
--- a/apps/gpc-prover-client/app/hooks/useIdentity.ts
+++ b/apps/gpc-prover-client/app/hooks/useIdentity.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Identity } from "@semaphore-protocol/core";
+import { Identity } from "@semaphore-protocol/identity";
 
 const useIdentity = () => {
   const [identity, setIdentity] = useState<Identity>();

--- a/apps/gpc-prover-client/app/util/generateProof.ts
+++ b/apps/gpc-prover-client/app/util/generateProof.ts
@@ -10,7 +10,7 @@ import {
   proofConfigFromJSON,
   podMembershipListsFromJSON
 } from "@pcd/gpc";
-import { Identity } from "@semaphore-protocol/core";
+import { Identity } from "@semaphore-protocol/identity";
 
 // Proof request specifies what we want to prove, which can be sent to the prover
 // to request a proof.

--- a/apps/gpc-prover-client/package.json
+++ b/apps/gpc-prover-client/package.json
@@ -13,7 +13,7 @@
     "@pcd/gpc": "^0.4.0",
     "@pcd/pod": "^0.5.0",
     "@pcd/proto-pod-gpc-artifacts": "^0.13.0",
-    "@semaphore-protocol/core": "4.5.0",
+    "@semaphore-protocol/identity": "4.5.0",
     "next": "^14.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -586,7 +586,7 @@
   resolved "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.3.tgz"
   integrity sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==
 
-"@semaphore-protocol/core@4.5.0", "@semaphore-protocol/core@^4.5.0":
+"@semaphore-protocol/core@^4.5.0":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@semaphore-protocol/core/-/core-4.5.0.tgz#889da9f4f8b7868c80dc8db1f070f5a17e2d7eab"
   integrity sha512-DQNLJIS4YGYnkDDtywpLf1gbQLWRhNm3X3dYGxODujApaATYQaPsFo6HHgHycMRIVgxrQwiAzSCAkTR8SNNgRg==


### PR DESCRIPTION
From @andrew, `if you're only using Semaphore V4 (not also V3 like Zupass needs to) you can use @semaphore-protocol/identity which is smaller.
Most devs will never use V3, so can probably use the smaller one too, though the /core approach does seem to be the safest one we have for both right now.`