### PR TITLE
Remove Semaphore ID consistency checks, change dateOfBirth to "date"

### DIFF
--- a/apps/pod-issuer-server/dist/routes/debug.js
+++ b/apps/pod-issuer-server/dist/routes/debug.js
@@ -31,7 +31,7 @@ debug.post("/id/issue", (req, res) => {
             idNumber: { type: "string", value: inputs.idNumber },
             firstName: { type: "string", value: inputs.firstName },
             lastName: { type: "string", value: inputs.lastName },
-            dateOfBirth: { type: "int", value: BigInt(inputs.dateOfBirth) },
+            dateOfBirth: { type: "date", value: new Date(inputs.dateOfBirth) },
             socialSecurityNumber: {
                 type: "string",
                 value: inputs.socialSecurityNumber

--- a/apps/pod-issuer-server/dist/routes/gov.js
+++ b/apps/pod-issuer-server/dist/routes/gov.js
@@ -31,19 +31,21 @@ gov.post("/issue", (0, express_jwt_1.expressjwt)({
     }
     try {
         // We already issued ID POD for this user, return the POD
-        const podStr = await (0, gov_1.getIDPODByEmail)(email);
-        if (podStr !== null) {
-            const pod = pod_1.POD.fromJSON(JSON.parse(podStr));
-            const owner = pod.content.asEntries().owner.value;
-            if (owner !== inputs.semaphorePublicKey) {
-                res
-                    .status(400)
-                    .send("Already issued POD for this user, but Semaphore Commitment doesn't match.");
-                return;
-            }
-            res.status(200).json({ pod: podStr });
-            return;
-        }
+        // const podStr = await getIDPODByEmail(email);
+        // if (podStr !== null) {
+        //   const pod = POD.fromJSON(JSON.parse(podStr));
+        //   const owner = pod.content.asEntries().owner.value;
+        //   if (owner !== inputs.semaphorePublicKey) {
+        //     res
+        //       .status(400)
+        //       .send(
+        //         "Already issued POD for this user, but Semaphore Commitment doesn't match."
+        //       );
+        //     return;
+        //   }
+        //   res.status(200).json({ pod: podStr });
+        //   return;
+        // }
         const user = await (0, gov_1.getGovUserByEmail)(email);
         if (user === null) {
             res.status(404).send("User not found");
@@ -56,7 +58,7 @@ gov.post("/issue", (0, express_jwt_1.expressjwt)({
             idNumber: { type: "string", value: user.idNumber },
             firstName: { type: "string", value: user.firstName },
             lastName: { type: "string", value: user.lastName },
-            dateOfBirth: { type: "int", value: user.dateOfBirth },
+            dateOfBirth: { type: "date", value: new Date(user.dateOfBirth) },
             socialSecurityNumber: {
                 type: "string",
                 value: user.socialSecurityNumber

--- a/apps/pod-issuer-server/dist/routes/gov.js
+++ b/apps/pod-issuer-server/dist/routes/gov.js
@@ -35,7 +35,7 @@ gov.post("/issue", (0, express_jwt_1.expressjwt)({
         if (podStr !== null) {
             const pod = pod_1.POD.fromJSON(JSON.parse(podStr));
             const owner = pod.content.asEntries().owner.value;
-            if (owner !== BigInt(inputs.semaphorePublicKey)) {
+            if (owner !== inputs.semaphorePublicKey) {
                 res
                     .status(400)
                     .send("Already issued POD for this user, but Semaphore Commitment doesn't match.");

--- a/apps/pod-issuer-server/dist/stores/gov.js
+++ b/apps/pod-issuer-server/dist/stores/gov.js
@@ -22,7 +22,7 @@ async function getGovUserByEmail(email) {
         email,
         firstName: lodash_1.default.upperFirst(names[0]),
         lastName: lodash_1.default.upperFirst(names[1]),
-        dateOfBirth: BigInt(dateOfBirth.getTime()),
+        dateOfBirth: dateOfBirth.getTime(),
         idNumber: `G${idNumber}`,
         socialSecurityNumber: ssn
     };

--- a/apps/pod-issuer-server/src/routes/debug.ts
+++ b/apps/pod-issuer-server/src/routes/debug.ts
@@ -42,7 +42,7 @@ debug.post("/id/issue", (req: Request, res: Response) => {
         idNumber: { type: "string", value: inputs.idNumber },
         firstName: { type: "string", value: inputs.firstName },
         lastName: { type: "string", value: inputs.lastName },
-        dateOfBirth: { type: "int", value: BigInt(inputs.dateOfBirth) },
+        dateOfBirth: { type: "date", value: new Date(inputs.dateOfBirth) },
         socialSecurityNumber: {
           type: "string",
           value: inputs.socialSecurityNumber

--- a/apps/pod-issuer-server/src/routes/gov.ts
+++ b/apps/pod-issuer-server/src/routes/gov.ts
@@ -37,21 +37,21 @@ gov.post(
 
     try {
       // We already issued ID POD for this user, return the POD
-      const podStr = await getIDPODByEmail(email);
-      if (podStr !== null) {
-        const pod = POD.fromJSON(JSON.parse(podStr));
-        const owner = pod.content.asEntries().owner.value;
-        if (owner !== inputs.semaphorePublicKey) {
-          res
-            .status(400)
-            .send(
-              "Already issued POD for this user, but Semaphore Commitment doesn't match."
-            );
-          return;
-        }
-        res.status(200).json({ pod: podStr });
-        return;
-      }
+      // const podStr = await getIDPODByEmail(email);
+      // if (podStr !== null) {
+      //   const pod = POD.fromJSON(JSON.parse(podStr));
+      //   const owner = pod.content.asEntries().owner.value;
+      //   if (owner !== inputs.semaphorePublicKey) {
+      //     res
+      //       .status(400)
+      //       .send(
+      //         "Already issued POD for this user, but Semaphore Commitment doesn't match."
+      //       );
+      //     return;
+      //   }
+      //   res.status(200).json({ pod: podStr });
+      //   return;
+      // }
 
       const user = await getGovUserByEmail(email);
       if (user === null) {
@@ -67,7 +67,7 @@ gov.post(
           idNumber: { type: "string", value: user.idNumber },
           firstName: { type: "string", value: user.firstName },
           lastName: { type: "string", value: user.lastName },
-          dateOfBirth: { type: "int", value: user.dateOfBirth },
+          dateOfBirth: { type: "date", value: new Date(user.dateOfBirth) },
           socialSecurityNumber: {
             type: "string",
             value: user.socialSecurityNumber

--- a/apps/pod-issuer-server/src/routes/gov.ts
+++ b/apps/pod-issuer-server/src/routes/gov.ts
@@ -41,7 +41,7 @@ gov.post(
       if (podStr !== null) {
         const pod = POD.fromJSON(JSON.parse(podStr));
         const owner = pod.content.asEntries().owner.value;
-        if (owner !== BigInt(inputs.semaphorePublicKey)) {
+        if (owner !== inputs.semaphorePublicKey) {
           res
             .status(400)
             .send(

--- a/apps/pod-issuer-server/src/stores/gov.ts
+++ b/apps/pod-issuer-server/src/stores/gov.ts
@@ -6,7 +6,7 @@ export type GovUser = {
   // hashedpassword: string;
   firstName: string;
   lastName: string;
-  dateOfBirth: bigint;
+  dateOfBirth: number;
   idNumber: string;
   socialSecurityNumber: string;
 };
@@ -31,7 +31,7 @@ export async function getGovUserByEmail(
     email,
     firstName: _.upperFirst(names[0]),
     lastName: _.upperFirst(names[1]),
-    dateOfBirth: BigInt(dateOfBirth.getTime()),
+    dateOfBirth: dateOfBirth.getTime(),
     idNumber: `G${idNumber}`,
     socialSecurityNumber: ssn
   };


### PR DESCRIPTION
This started as a small change to fix a type error, but ended up larger as I debugged more deeply.  Explanation of what I changed and why: There are consistency checks which attempt to ensure not using multiple Semaphore IDs for the same email.  This makes sense in a real app, but for a demo app it ends up causing confusion whenever a user clicks Reset in the ZuKyc site (generating a new Semaphore ID) or when multiple users share the same email on the live demo server.  Since there's no real user persistency here, I removed the checking and persistence of the semaphore ID and the govID POD.  Instead the Gov and Deel sites will simply always generate a new POD with the input data.

Along the way I also changed the dateOfBirth field to use the "date" value type, which didn't exist yet when this example was written.