### PR TITLE
Custom turbo config for GPC artifacts

### DIFF
--- a/apps/gpc-prover-client/next.config.js
+++ b/apps/gpc-prover-client/next.config.js
@@ -19,6 +19,9 @@ module.exports = {
         ),
         process: "process/browser"
       };
+
+      // Deploys GPC artifacts into a public dir where they can be downloaded
+      // by browsers.
       config.plugins.push(
         new CopyWebpackPlugin({
           patterns: [
@@ -35,6 +38,10 @@ module.exports = {
   },
   async headers() {
     return [
+      // Makes the GPC artifacts directory downloadable, including by pages
+      // running on a different origin URL.  This is specifically to allow the
+      // verifier to also download the same artifacts.  The "Origin" of *
+      // allows htis, but could be narrower if desired for security.
       {
         source: "/artifacts/(.*)",
         headers: [

--- a/apps/gpc-prover-client/turbo.json
+++ b/apps/gpc-prover-client/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": [".next/**", "!.next/cache/**", "public/artifacts/**"]
+    }
+  }
+}


### PR DESCRIPTION
Customize the turbo config to be aware of the GPC artifacts dir, so that it is cached with other build outputs.
This fixes an issue I noticed in my last PR where cached build ended up with deployments missing those artifacts, leading to 404s during prove/verify.
